### PR TITLE
Use the new setAllowedTypes method signature

### DIFF
--- a/src/Ftrrtf/Rollbar/Environment.php
+++ b/src/Ftrrtf/Rollbar/Environment.php
@@ -305,11 +305,7 @@ class Environment
             )
         );
 
-        $resolver->setAllowedTypes(
-            array(
-                'scrub_fields' => 'array',
-            )
-        );
+        $resolver->setAllowedTypes('scrub_fields', 'array');
 
         $resolver->setRequired($this->requiredOptions);
     }


### PR DESCRIPTION
This will remove the deprecation notice:

Calling the Symfony\Component\OptionsResolver\OptionsResolver::setAllowedTypes method with an array of options is deprecated since version 2.6 and will be removed in 3.0. Use the new signature with a single option instead.