### PR TITLE
Removed deprecated OptionsResolverInterface.

### DIFF
--- a/src/Ftrrtf/Rollbar/Environment.php
+++ b/src/Ftrrtf/Rollbar/Environment.php
@@ -4,7 +4,6 @@ namespace Ftrrtf\Rollbar;
 
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
  * Class Request
@@ -278,9 +277,9 @@ class Environment
     }
 
     /**
-     * @param OptionsResolverInterface $resolver
+     * @param OptionsResolver $resolver
      */
-    protected function setDefaultOptions(OptionsResolverInterface $resolver)
+    protected function setDefaultOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             array(

--- a/src/Ftrrtf/Rollbar/Notifier.php
+++ b/src/Ftrrtf/Rollbar/Notifier.php
@@ -7,7 +7,6 @@ use Ftrrtf\Rollbar\Transport\Curl;
 use Ftrrtf\Rollbar\Report;
 use Ftrrtf\Rollbar\Report\ReportInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
  * Class Notifier
@@ -316,9 +315,9 @@ class Notifier
     }
 
     /**
-     * @param OptionsResolverInterface $resolver
+     * @param OptionsResolver $resolver
      */
-    protected function setDefaultOptions(OptionsResolverInterface $resolver)
+    protected function setDefaultOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             array(


### PR DESCRIPTION
Sorry, but I forgot to remove the deprecated OptionsResolverInterface in an earlier PR.  This should fix the situation.

It is recommended that we just use the OptionsResolver class instead of the interface.