### PR TITLE
Bug fixes in Environment.php/Notifier.php

### DIFF
--- a/src/Environment.php
+++ b/src/Environment.php
@@ -279,7 +279,7 @@ class Environment
     /**
      * @param Options $resolver
      */
-    protected function setDefaultOptions(Options $resolver)
+    protected function setDefaultOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             array(
@@ -304,7 +304,7 @@ class Environment
             )
         );
 
-        $resolver->setAllowedTypes('scrub_fields', ['array']);
+        $resolver->setAllowedTypes(['scrub_fields' => 'array']);
 
         $resolver->setRequired($this->requiredOptions);
     }

--- a/src/Notifier.php
+++ b/src/Notifier.php
@@ -317,7 +317,7 @@ class Notifier
     /**
      * @param Options $resolver
      */
-    protected function setDefaultOptions(Options $resolver)
+    protected function setDefaultOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             array(


### PR DESCRIPTION
Fixes issue #5, other bugs.
- Type hinting of setDefaultOptions methods of Environment and Notifier set to `OptionsResolver`, as that is what they're actually being passed.
- Fixed arguments of `setAllowedTypes` call, takes an associative array.
